### PR TITLE
Add fortune telling service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Fortune Teller
+
+This project provides a simple fortune telling service based on Thai and Chinese traditions.
+
+## Usage
+
+Run the CLI application:
+
+```bash
+python3 fortune.py
+```
+
+You will be prompted for the day of the week and your birth year. The program will then output your Thai fortune followed by your Chinese zodiac fortune.
+
+To run the Streamlit web app:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+This launches a web interface where you can select your birth day and year to display both fortunes.
+
+## Requirements
+
+The only Python package needed is `streamlit`. Install it with:
+
+```bash
+pip install -r requirements.txt
+```

--- a/fortune.py
+++ b/fortune.py
@@ -1,1 +1,74 @@
+# Fortune telling service for Thai and Chinese traditions
 
+THAI_FORTUNES = {
+    'monday':    ('yellow', 'intelligent and charming'),
+    'tuesday':   ('pink',   'confident and competitive'),
+    'wednesday': ('green',  'creative and thoughtful'),
+    'thursday':  ('orange', 'generous and wise'),
+    'friday':    ('blue',   'sociable and fun-loving'),
+    'saturday':  ('purple', 'strong and independent'),
+    'sunday':    ('red',    'energetic and decisive'),
+}
+
+ZODIAC_ANIMALS = [
+    'Rat', 'Ox', 'Tiger', 'Rabbit', 'Dragon', 'Snake',
+    'Horse', 'Goat', 'Monkey', 'Rooster', 'Dog', 'Pig'
+]
+
+ZODIAC_TRAITS = {
+    'Rat': 'resourceful and quick-witted',
+    'Ox': 'reliable and determined',
+    'Tiger': 'brave and confident',
+    'Rabbit': 'gentle and compassionate',
+    'Dragon': 'ambitious and energetic',
+    'Snake': 'wise and enigmatic',
+    'Horse': 'active and free-spirited',
+    'Goat': 'calm and gentle',
+    'Monkey': 'clever and curious',
+    'Rooster': 'hardworking and observant',
+    'Dog': 'loyal and honest',
+    'Pig': 'generous and diligent',
+}
+
+def get_thai_fortune(day: str):
+    day_key = day.strip().lower()
+    return THAI_FORTUNES.get(day_key, (None, None))
+
+
+def get_chinese_zodiac(year: int):
+    index = (year - 1900) % 12
+    animal = ZODIAC_ANIMALS[index]
+    trait = ZODIAC_TRAITS[animal]
+    return animal, trait
+
+
+def main():
+    day = input('Enter the day of the week you were born: ')
+    year_input = input('Enter the year you were born: ')
+    try:
+        year = int(year_input)
+    except ValueError:
+        print('Invalid year provided.')
+        return
+
+    color, thai_trait = get_thai_fortune(day)
+    if color is None:
+        print('Unknown day of the week provided.')
+        return
+
+    animal, zodiac_trait = get_chinese_zodiac(year)
+
+    print('\nThai Fortune')
+    print('------------')
+    print(f'Day: {day.strip().title()}')
+    print(f'Lucky Color: {color.title()}')
+    print(f'Traits: {thai_trait}')
+
+    print('\nChinese Fortune')
+    print('---------------')
+    print(f'Zodiac Animal: {animal}')
+    print(f'Traits: {zodiac_trait}')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,24 @@
+import streamlit as st
+from fortune import get_thai_fortune, get_chinese_zodiac, THAI_FORTUNES
+
+st.title('Fortune Teller')
+
+# Select day of the week
+choices = [day.title() for day in THAI_FORTUNES.keys()]
+day = st.selectbox('Day of the week you were born:', choices)
+
+# Input for birth year
+year = st.number_input('Year you were born:', min_value=1900, max_value=2100, step=1)
+
+if st.button('Tell my fortune'):
+    color, thai_trait = get_thai_fortune(day)
+    animal, zodiac_trait = get_chinese_zodiac(int(year))
+
+    st.subheader('Thai Fortune')
+    st.write(f'Day: {day}')
+    st.write(f'Lucky Color: {color.title()}')
+    st.write(f'Traits: {thai_trait}')
+
+    st.subheader('Chinese Fortune')
+    st.write(f'Zodiac Animal: {animal}')
+    st.write(f'Traits: {zodiac_trait}')

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,7 +8,12 @@ choices = [day.title() for day in THAI_FORTUNES.keys()]
 day = st.selectbox('Day of the week you were born:', choices)
 
 # Input for birth year
-year = st.number_input('Year you were born:', min_value=1900, max_value=2100, step=1)
+year = st.number_input(
+    'Year you were born:',
+    min_value=1900,
+    max_value=2100,
+    step=1,
+)
 
 if st.button('Tell my fortune'):
     color, thai_trait = get_thai_fortune(day)


### PR DESCRIPTION
## Summary
- implement a Thai and Chinese fortune telling service
- ask the user for their birth day and year
- display the Thai fortune (day, color, traits) and the Chinese fortune (zodiac animal and traits)

## Testing
- `python3 fortune.py <<EOF
Monday
1992
EOF`
- `python3 fortune.py <<EOF
Sunday
1989
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684fcf2c40688325876e682ac470f4a4